### PR TITLE
feat: change address prefix

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -113,7 +113,7 @@ import (
 )
 
 const (
-	AccountAddressPrefix = "cosmos"
+	AccountAddressPrefix = "ju"
 	Name                 = "julia"
 )
 


### PR DESCRIPTION
Change address prefix from default `cosmos` to `ju`

Eg: 
```
🙂 Created account "alice" with address "ju1xvxvzrnd4jp09w6qyxtfqqeprs2w54444xdzxy" with mnemonic: "hidden phase"
🙂 Created account "bob" with address "ju1wm9qc2v2tkx4n4nelff7r3rs6mp8lynl08yf9u" with mnemonic: "hidden phase"

```